### PR TITLE
fixing typo/legacy option in usage.md 

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,7 +40,7 @@ droid -cf droid_config.toml --platform microsoft_xdr \
 ```bash
 droid -cf droid_config.toml --platform splunk \
 --rules rules/sigma/ \
---compile -d
+--convert -d
 ```
 
 ???+ info


### PR DESCRIPTION
In the Usage doc the argument listed under the Convert heading is labeled as "--complie", however the [source](https://github.com/certeu/droid/blob/main/src/droid/__main__.py)  seems to indicate this should be "--convert" instead. 